### PR TITLE
PC: Added missing description for Help Another

### DIFF
--- a/custom_server_data/project_chimera/Abilities/Help Another.json
+++ b/custom_server_data/project_chimera/Abilities/Help Another.json
@@ -1,8 +1,0 @@
-{
-    "name": "Help Another",
-    "type": "None",
-    "accuracy": "Social Stat",
-    "target": "One Ally",
-    "effect": "Choose a Social Stat for this move upon use, that is used for the Accuracy Dice. If successful add one die to the Action of an Ally. Up to 6 dice may be added this way.",
-    "category": "Support"
-  }

--- a/custom_server_data/project_chimera/Abilities/Spikes.json
+++ b/custom_server_data/project_chimera/Abilities/Spikes.json
@@ -1,9 +1,0 @@
-{
-  "name": "Spikes",
-  "type": "Ground",
-  "accuracy": "Dexterity",
-  "target": "Foe's Battlefield",
-  "effect": "Hazard. Sets up Spikes on the opponent's battlefield. When triggered this deals 1 damage. Add additional damage to this for each layer of Spikes. Additional Layers can be set with a Bonus Action of Dexterity+Rank, needing 5 successes for the second. And another 15 for the third layer.",
-  "description": "The pokemon sets up a layer of sharp caltrops on the field, serving as a sufficient trap to inhibit movement.",
-  "category": "Support"
-}

--- a/custom_server_data/project_chimera/Abilities/Stealth Rocks.json
+++ b/custom_server_data/project_chimera/Abilities/Stealth Rocks.json
@@ -1,9 +1,0 @@
-{
-    "name": "Stealth Rocks",
-    "type": "Rock",
-    "accuracy": "Dexterity",
-    "target": "Foe's Battlefield",
-    "effect": "Hazard. Deals 1 Damage when the foe swaps targets with an Attacking Move, this is upgraded to 2 damage if the foe is weak to Rock type attacks.",
-    "description": "A trap of floating rocks are scattered around the battlefield, making movement difficult without getting hurt.",
-    "category": "Support"
-  }

--- a/custom_server_data/project_chimera/Abilities/Toxic Spikes.json
+++ b/custom_server_data/project_chimera/Abilities/Toxic Spikes.json
@@ -1,9 +1,0 @@
-{
-    "name": "Toxic Spikes",
-    "type": "Poison",
-    "accuracy": "Dexterity",
-    "target": "Foe's Battlefield",
-    "effect": "Hazard. Sets up Poison Spikes on the opponent's battlefield. When triggered roll 3 chance dice to poison the foe. Further triggers will cause a single chance die to be rolled to upgrade the poison to Badly Poisoned. This has no effect on Flying types, Steel types, Poison Types or Pokemon with the ability Levitate. Poison types may also use an action to instantly clear Toxic Spikes from their side of the Battlefield!",
-    "description": "The pokemon sets up a layer of caltrops coated in poison. Accidentally stepping on one serves as a surefire way to get poisoned.",
-    "category": "Support"
-  }

--- a/custom_server_data/project_chimera/Moves/Help Another.json
+++ b/custom_server_data/project_chimera/Moves/Help Another.json
@@ -4,6 +4,6 @@
     "accuracy": "Social Stat",
     "target": "One Ally",
     "effect": "Choose a Social Stat for this move upon use, that is used for the Accuracy Dice. If successful add one die to the Action of an Ally. Up to 6 dice may be added this way.",
-    "description": "You reach out and cheer on another pokemon to help them.",
+    "description": "Do something helpful for a friend!",
     "category": "Support"
-  }
+}

--- a/custom_server_data/project_chimera/Moves/Help Another.json
+++ b/custom_server_data/project_chimera/Moves/Help Another.json
@@ -1,6 +1,6 @@
 {
     "name": "Help Another",
-    "type": "None",
+    "type": "Typeless",
     "accuracy": "Social Stat",
     "target": "One Ally",
     "effect": "Choose a Social Stat for this move upon use, that is used for the Accuracy Dice. If successful add one die to the Action of an Ally. Up to 6 dice may be added this way.",

--- a/custom_server_data/project_chimera/Moves/Help Another.json
+++ b/custom_server_data/project_chimera/Moves/Help Another.json
@@ -4,5 +4,6 @@
     "accuracy": "Social Stat",
     "target": "One Ally",
     "effect": "Choose a Social Stat for this move upon use, that is used for the Accuracy Dice. If successful add one die to the Action of an Ally. Up to 6 dice may be added this way.",
+    "description": "You reach out and cheer on another pokemon to help them.",
     "category": "Support"
   }


### PR DESCRIPTION
Added missing description for Help Another (Temp until I get given a proper one), actually removed duplicate moves that were erroneously in abilities because I can't read apparently.